### PR TITLE
Fix mixed declarations and code issues

### DIFF
--- a/hashids.c
+++ b/hashids.c
@@ -415,17 +415,17 @@ size_t
 hashids_encode(hashids_t *hashids, char *buffer,
     size_t numbers_count, unsigned long long *numbers)
 {
+    size_t i, j, result_len, guard_index, half_length_ceil, half_length_floor;
+    unsigned long long number, number_copy, numbers_hash;
+    int p_max;
+    char lottery, ch, temp_ch, *p, *buffer_end, *buffer_temp;
+
     /* bail out if no numbers */
     if (HASHIDS_UNLIKELY(!numbers_count)) {
         buffer[0] = '\0';
 
         return 0;
     }
-
-    size_t i, j, result_len, guard_index, half_length_ceil, half_length_floor;
-    unsigned long long number, number_copy, numbers_hash;
-    int p_max;
-    char lottery, ch, temp_ch, *p, *buffer_end, *buffer_temp;
 
     /* return an estimation if no buffer */
     if (HASHIDS_UNLIKELY(!buffer)) {

--- a/pg_hashids.c
+++ b/pg_hashids.c
@@ -130,6 +130,7 @@ id_decode( PG_FUNCTION_ARGS )
   // Declaration
   hashids_t *hashids;
   unsigned long long *numbers;
+  unsigned long long *resultValues;
   int numbers_count;
 
   ArrayType* resultArray;
@@ -151,7 +152,7 @@ id_decode( PG_FUNCTION_ARGS )
   hashids_free(hashids);
 
   resultArray = alloc_array(numbers_count);
-  unsigned long long *resultValues = (unsigned long long *)ARR_DATA_PTR(resultArray);
+  resultValues = (unsigned long long *)ARR_DATA_PTR(resultArray);
 
   memcpy(resultValues, numbers, numbers_count * sizeof(unsigned long long));
 


### PR DESCRIPTION
Build fails on alpine linux due to ISO C90 standards:

```
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -O2 -fPIC -I. -I./ -I/usr/local/include/postgresql/server -I/usr/local/include/postgresql/internal -D_GNU_SOURCE -I/usr/include/libxml2   -c -o pg_hashids.o pg_hashids.c
pg_hashids.c: In function 'id_decode':
pg_hashids.c:154:3: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
   unsigned long long *resultValues = (unsigned long long *)ARR_DATA_PTR(resultArray);
   ^~~~~~~~
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -O2 -fPIC -I. -I./ -I/usr/local/include/postgresql/server -I/usr/local/include/postgresql/internal -D_GNU_SOURCE -I/usr/include/libxml2   -c -o hashids.o hashids.c
hashids.c: In function 'hashids_encode':
hashids.c:425:5: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
     size_t i, j, result_len, guard_index, half_length_ceil, half_length_floor;
     ^~~~~~
```