### PR TITLE
Include VARHDRSZ when allocating return value

### DIFF
--- a/pg_hashids.c
+++ b/pg_hashids.c
@@ -69,7 +69,7 @@ id_encode( PG_FUNCTION_ARGS )
   hash = palloc0(hashids_estimate_encoded_size(hashids, 1, &number));
 
   bytes_encoded = hashids_encode_one(hashids, hash, number);
-  hash_string = (text *)palloc( bytes_encoded );
+  hash_string = (text *)palloc(bytes_encoded + VARHDRSZ);
 
   SET_VARSIZE(hash_string, bytes_encoded + VARHDRSZ);
   strncpy( VARDATA(hash_string), hash, bytes_encoded );


### PR DESCRIPTION
According to the PostgreSQL documentation, the VARHDRSZ header needs to be included in the allocation for the return value.  Without this, the allocations are 4 bytes short (which explains the results described in issue #19), writing the data flies off the end of the allocated space (by 4 bytes), and is then overwritten by subsequent allocations.

From the docs:
```
char buffer[40]; /* our source data */
...
text *destination = (text *) palloc(VARHDRSZ + 40);
SET_VARSIZE(destination, VARHDRSZ + 40);
memcpy(destination->data, buffer, 40);
```

(Notice the `VARHDRSZ + 40` in *both* the `palloc()` and the `SET_VARSIZE()` calls.  While the existing code had `+ VARHDRSZ` in the `VARSIZE()` call, it was missing from `palloc()`.

Fixes #19, and probably #15.

Signed-off-by: Jared Reisinger <jaredreisinger@hotmail.com>